### PR TITLE
Use modern adoptedStyleSheets API

### DIFF
--- a/packages/ember-wc/src/index.ts
+++ b/packages/ember-wc/src/index.ts
@@ -26,9 +26,9 @@ export function wrapApp(
       );
 
       if (options.styles) {
-        const style = document.createElement('style');
-        style.textContent = options.styles;
-        shadow.appendChild(style);
+        const sheet = new CSSStyleSheet();
+        sheet.replaceSync(options.styles);
+        shadow.adoptedStyleSheets.push(sheet);
       }
 
       const appConfig = {


### PR DESCRIPTION
Built on top of #11 (merge first!), this changes the implementation to use more modern [adoptedStyleSheets](https://developer.mozilla.org/en-US/docs/Web/API/Document/adoptedStyleSheets) API.